### PR TITLE
Allow user to choose citation style

### DIFF
--- a/base/proposal.dtx
+++ b/base/proposal.dtx
@@ -646,7 +646,7 @@
 \renewcommand{\familydefault}{\sfdefault}
 \RequirePackage[scaled=.90]{helvet}
 \RequirePackage{textcomp}
-\RequirePackage[hyperref=auto,style=alphabetic,defernumbers=true,backend=bibtex,firstinits=true,maxbibnames=9,maxcitenames=3]{biblatex}[2010/11-19]
+\RequirePackage[hyperref=auto,defernumbers=true,backend=bibtex,firstinits=true,maxbibnames=9,maxcitenames=3]{biblatex}[2010/11-19]
 \RequirePackage{csquotes}
 \RequirePackage{mdframed}
 %    \end{macrocode}

--- a/base/proposal.sty
+++ b/base/proposal.sty
@@ -28,7 +28,7 @@
 \renewcommand{\familydefault}{\sfdefault}
 \RequirePackage[scaled=.90]{helvet}
 \RequirePackage{textcomp}
-\RequirePackage[hyperref=auto,style=alphabetic,defernumbers=true,backend=bibtex,firstinits=true,maxbibnames=9,maxcitenames=3]{biblatex}[2010/11-19]
+\RequirePackage[hyperref=auto,defernumbers=true,backend=bibtex,firstinits=true,maxbibnames=9,maxcitenames=3]{biblatex}[2010/11-19]
 \RequirePackage{csquotes}
 \RequirePackage{mdframed}
 \RequirePackage{pdata}


### PR DESCRIPTION
Using:

```
\PassOptionsToPackage{style= numeric}{biblatex}
\documentclass{dfgproposal}
```

to overwrite the citation style does not work (in contrast to e.g. backend= biber or natbib= true).
Therefore, I removed the style specification from the DTX, making `\PassOptionsToPackage{style=numeric}{biblatex}` possible. Using `\PassOptionsToPackage{style=alphabetic}{biblatex}` corresponds to the former default.