### PR TITLE
Empty acro init

### DIFF
--- a/base/proposal.dtx
+++ b/base/proposal.dtx
@@ -700,6 +700,7 @@
 %    \end{macrocode}
 % We specify the page headings. 
 %    \begin{macrocode}
+\let\prop@gen@acronym\@empty
 \newif\ifofpage\ofpagefalse
 \ifgrantagreement
 \fancyhead{}

--- a/base/proposal.sty
+++ b/base/proposal.sty
@@ -52,6 +52,7 @@
 \renewcommand\ednoteshape{\sl\footnotesize}
 \ifpublic\excludecomment{private}\else\includecomment{private}\fi
 \setcounter{secnumdepth}{3}
+\let\prop@gen@acronym\@empty
 \newif\ifofpage\ofpagefalse
 \ifgrantagreement
 \fancyhead{}


### PR DESCRIPTION
It seems the acronym token `\prop@gen@acronym` was not initialized to `\empty` such that later comparisons lead to errors like:

```
! Undefined control sequence.
\prop@proposal ...RGE Acronym: {\prop@gen@acronym 
```

if the acronym was not specified to be empty **by the user** like: 

```
\begin{proposal}[
    acronym= {},
```

This PR initializes the token such that no error occurs if the user does not specify the acronym at all.
